### PR TITLE
Se le pasa el UnboundMethod a cada condition

### DIFF
--- a/src/aspectable.rb
+++ b/src/aspectable.rb
@@ -7,7 +7,8 @@ module AbstractAspectable
   include Condition
 
   def where (*conditions)
-    get_aspectable_methods.select do |method|
+    get_aspectable_methods.select do |method_symbol|
+        method = get_aspectable_method(method_symbol)
         conditions.all? do |condition|
           condition.call(method)
         end


### PR DESCRIPTION
Como estaba antes se le pasaba el símbolo a la condición, habría que pasarle el unbound method para que la condición pueda ver comsas como visibilidad, cantidad de parámetros, etc. (Idem a transformer)